### PR TITLE
Host ip addresses can be retrieved from host data

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Requirements
 
 Before this role runs you also needs to gather facts for the group which you are writing to a hosts file.
 
+Alternatively you can use data specified for each host to populate the hosts file.
+
 Role Variables
 --------------
 
@@ -24,6 +26,13 @@ hosts_file_num_interfaces: [ 0, 1, 2, 3, 4 ]
 
  - If your machines have more than 5 ipv4_addresses add some numbers to the hosts_file_num_interfaces list
  - Change hosts_file_ip_match to match the IP addresses you want to add to the hosts file
+
+To use data defined for the hosts as a source of the data you can specify the following variables.
+
+<pre>
+hosts_ip_source: "hostdata"
+ipaddress_source_var: "ip_address"
+</pre>
 
 Dependencies
 ------------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -8,3 +8,5 @@ hosts_file_to_populate: "/tmp/hosts"
 hosts_file_ip_match: "10.11"
 # the number of ipv4_addresses (elements in ansible_all_ipv4_addresses in each host in hosts_file_ansible_group_to_hosts_file)
 hosts_file_num_interfaces: [ 0, 1, 2, 3, 4 ]
+hosts_ip_source: "facts"
+ipaddress_source_var: "ip_address"

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,0 +1,19 @@
+---
+# tasks file for ansible-role-hosts-inventory
+
+# Add up to hosts_file_num_interfaces number of ipv4 addresses from the ansible_all_ipv4_addresses list from each host in ansible group hosts_file_ansible_group_to_hosts_file as long as it contains hosts_file_ip_match
+- name: "Build hosts file form facts"
+  lineinfile:
+        dest='{{ hosts_file_to_populate }}'
+        regexp='^{{ hostvars[item[0]].ansible_all_ipv4_addresses[item[1]] }} {{ hostvars[item[0]].ansible_hostname }} {{ item[0] }}$'
+        line="{{ hostvars[item[0]].ansible_all_ipv4_addresses[item[1]] }} {{ hostvars[item[0]].ansible_hostname }} {{ item[0] }}"
+        state=present
+        create=true
+        backup=true
+  when: 
+   - hostvars[item[0]].ansible_all_ipv4_addresses is defined 
+   - hostvars[item[0]].ansible_all_ipv4_addresses[item[1]] is defined 
+   - hosts_file_ip_match in hostvars[item[0]].ansible_all_ipv4_addresses[item[1]]
+  with_nested: 
+   - hosts_file_ansible_group_to_hosts_file
+   - hosts_file_num_interfaces

--- a/tasks/hostdata.yml
+++ b/tasks/hostdata.yml
@@ -1,0 +1,15 @@
+---
+# tasks file for ansible-role-hosts-inventory
+
+- name: "Build hosts file form defined host data"
+  lineinfile:
+        dest='{{ hosts_file_to_populate }}'
+        regexp='^{{ hostvars[item][ipaddress_source_var] }} {{ item }}$'
+        line="{{ hostvars[item][ipaddress_source_var] }} {{ item }}"
+        state=present
+        create=true
+        backup=true
+  when:
+   - hostvars[item][ipaddress_source_var] is defined
+  with_items: hosts_file_ansible_group_to_hosts_file
+

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,19 +3,8 @@
 
 - debug: var=hosts_file_ansible_group_to_hosts_file
 
-# Add up to hosts_file_num_interfaces number of ipv4 addresses from the ansible_all_ipv4_addresses list from each host in ansible group hosts_file_ansible_group_to_hosts_file as long as it contains hosts_file_ip_match
-- name: "Build hosts file"
-  lineinfile:
-        dest='{{ hosts_file_to_populate }}'
-        regexp='^{{ hostvars[item[0]].ansible_all_ipv4_addresses[item[1]] }} {{ hostvars[item[0]].ansible_hostname }} {{ item[0] }}$'
-        line="{{ hostvars[item[0]].ansible_all_ipv4_addresses[item[1]] }} {{ hostvars[item[0]].ansible_hostname }} {{ item[0] }}"
-        state=present
-        create=true
-        backup=true
-  when: 
-   - hostvars[item[0]].ansible_all_ipv4_addresses is defined 
-   - hostvars[item[0]].ansible_all_ipv4_addresses[item[1]] is defined 
-   - hosts_file_ip_match in hostvars[item[0]].ansible_all_ipv4_addresses[item[1]]
-  with_nested: 
-   - hosts_file_ansible_group_to_hosts_file
-   - hosts_file_num_interfaces
+- include: facts.yml
+  when: hosts_ip_source == "facts"
+
+- include: hostdata.yml
+  when: hosts_ip_source == "hostdata"


### PR DESCRIPTION
Previously this role used facts to figure out host ip data. This change
adds another mode to the role where it can take the host ip data from
some predefined variable of the host. The default function remained the
same.
