### PR TITLE
Add a configurable handler for hosts file updates

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,3 +10,5 @@ hosts_file_ip_match: "10.11"
 hosts_file_num_interfaces: [ 0, 1, 2, 3, 4 ]
 hosts_ip_source: "facts"
 ipaddress_source_var: "ip_address"
+# what handler to call after updating hosts file (default is to call nothing)
+#hosts_update_handler: ""

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -4,7 +4,7 @@
 # Add up to hosts_file_num_interfaces number of ipv4 addresses from the ansible_all_ipv4_addresses list from each host in ansible group hosts_file_ansible_group_to_hosts_file as long as it contains hosts_file_ip_match
 - name: "Build hosts file from facts"
   lineinfile:
-        dest='{{ hosts_file_to_populate }}'
+        dest="{{ hosts_file_to_populate }}"
         regexp='^{{ hostvars[item[0]].ansible_all_ipv4_addresses[item[1]] }} {{ hostvars[item[0]].ansible_hostname }} {{ item[0] }}$'
         line="{{ hostvars[item[0]].ansible_all_ipv4_addresses[item[1]] }} {{ hostvars[item[0]].ansible_hostname }} {{ item[0] }}"
         state=present
@@ -17,3 +17,4 @@
   with_nested: 
    - "{{ hosts_file_ansible_group_to_hosts_file }}"
    - "{{ hosts_file_num_interfaces }}"
+  notify: "{{ hosts_update_handler | default(omit) }}"

--- a/tasks/hostdata.yml
+++ b/tasks/hostdata.yml
@@ -3,7 +3,7 @@
 
 - name: "Build hosts file from defined host data with lineinfile"
   lineinfile:
-        dest='{{ hosts_file_to_populate }}'
+        dest="{{ hosts_file_to_populate }}"
         regexp='^{{ hostvars[item][ipaddress_source_var] }} {{ item }}$'
         line="{{ hostvars[item][ipaddress_source_var] }} {{ item }}"
         state=present
@@ -11,4 +11,4 @@
         backup=true
   when: (hostvars[item][ipaddress_source_var] is defined) and (hostvars[item]['hosts_file_exclude'] is not defined)
   with_items: "{{ hosts_file_ansible_group_to_hosts_file }}"
-
+  notify: "{{ hosts_update_handler | default(omit) }}"


### PR DESCRIPTION
When the hosts file is updated, it can be useful to send a notification
to some service like e.g. dnsmasq so that changes in the hosts file are
taken into use. Add a configurable handler name to all the tasks in this
role that update the hosts file. The default handler is "restart
dnsmasq" which is defined here:
https://github.com/CSC-IT-Center-for-Science/ansible-role-dnsmasq