### PR TITLE
Use include_tasks instead of include

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Role Variables
 See defaults/main.yml for the actual list
 
 <pre>
-hosts_file_ansible_group_to_hosts_file: "{{ groups.all }}"
+hosts_file_ansible_group_to_hosts_file: "{{ groups.all|sort }}"
 hosts_file_to_populate: "/tmp/hosts"
 # ip_match: look for this string in the IP address
 hosts_file_ip_match: "10.11"
@@ -27,6 +27,7 @@ hosts_file_num_interfaces: [ 0, 1, 2, 3, 4 ]
 
  - If your machines have more than 5 ipv4_addresses add some numbers to the hosts_file_num_interfaces list
  - Change hosts_file_ip_match to match the IP addresses you want to add to the hosts file
+ - By sorting the groups then the hosts file looks the same every time
 
 To use data defined for the hosts as a source of the data you can specify the following variables.
 

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,7 +14,7 @@ galaxy_info:
   # - Apache
   # - CC-BY
   license: MIT
-  min_ansible_version: 1.9
+  min_ansible_version: 2.4
   #
   # Below are all platforms currently available. Just uncomment
   # the ones that apply to your role. If you don't see your 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 # tasks file for ansible-role-hosts-inventory
 
-- include: facts.yml
+- include_tasks: facts.yml
   when: hosts_ip_source == "facts"
 
-- include: hostdata.yml
+- include_tasks: hostdata.yml
   when: hosts_ip_source == "hostdata"
 
-- include: template.yml
+- include_tasks: template.yml
   when: hosts_ip_source == "template"

--- a/tests/devel-centos7/Dockerfile
+++ b/tests/devel-centos7/Dockerfile
@@ -13,9 +13,8 @@ RUN yum clean all && \
     yum -y install acl sudo && \
     sed -i -e 's/^Defaults.*requiretty/Defaults    !requiretty/' -e 's/^%wheel.*ALL$/%wheel    ALL=(ALL)    NOPASSWD: ALL/' /etc/sudoers && \
     yum -y install PyYAML python-jinja2 python-httplib2 python-keyczar python-paramiko python-setuptools git python-pip && \
-    pip install --upgrade pip && \
     pip install requests[security] && \
-    pip install pyrax pysphere boto boto3 passlib dnspython && \
+    pip install passlib dnspython && \
     sh -c 'yum -y remove libffi-devel || yum -y --setopt=tsflags=noscripts remove libffi-devel' && \
     yum -y remove $(rpm -qa "*-devel") && \
     yum -y groupremove "Development tools" && \


### PR DESCRIPTION
It's new with ansible 2.4. The include: is still there in 2.5 but it's deprecated
and it looks like it's similar to import: - meaning it will skip a lot
of things.

With several hundreds of hosts in the inventory to skip running a
playbook that uses the templating style the playbook went from 3m6s
to 2m21s or a reduction of 45 seconds.

Also a note about using "| sort" jinja2 filter on the groups to get the
list of hosts sorted